### PR TITLE
fix(supabase/migrations): Alter all ustad_ leftover

### DIFF
--- a/supabase/migrations/20241107080857_alter_ustad_id_to_ustadz_id.sql
+++ b/supabase/migrations/20241107080857_alter_ustad_id_to_ustadz_id.sql
@@ -6,8 +6,19 @@ ALTER TABLE "public"."halaqah" DROP COLUMN IF EXISTS "ustad_id";
 
 ALTER TABLE "public"."halaqah" ADD COLUMN IF NOT EXISTS "ustadz_id" character varying;
 
-ALTER TABLE "public"."halaqah" ADD CONSTRAINT "halaqah_ustadz_id_fkey"
-    FOREIGN KEY ("ustadz_id") REFERENCES "users"("email") NOT VALID;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'halaqah_ustadz_id_fkey'
+          AND conrelid = 'public.halaqah'::regclass
+    ) THEN
+        ALTER TABLE "public"."halaqah"
+        ADD CONSTRAINT "halaqah_ustadz_id_fkey"
+        FOREIGN KEY ("ustadz_id") REFERENCES "users"("email") NOT VALID;
+    END IF;
+END $$;
 
 ALTER TABLE "public"."halaqah" VALIDATE CONSTRAINT "halaqah_ustadz_id_fkey";
 

--- a/supabase/migrations/20241107092130_alter_ustad_id_to_ustadz_id_leftover.sql
+++ b/supabase/migrations/20241107092130_alter_ustad_id_to_ustadz_id_leftover.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+ALTER TABLE "public"."activities" DROP CONSTRAINT IF EXISTS "activities_ustad_id_fkey";
+
+ALTER TABLE "public"."activities" DROP COLUMN IF EXISTS "ustad_id";
+
+ALTER TABLE "public"."activities" ADD COLUMN IF NOT EXISTS "ustadz_id" character varying;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'activities_ustadz_id_fkey'
+          AND conrelid = 'public.activities'::regclass
+    ) THEN
+        ALTER TABLE "public"."activities"
+        ADD CONSTRAINT "activities_ustadz_id_fkey"
+        FOREIGN KEY ("ustadz_id") REFERENCES "users"("email") NOT VALID;
+    END IF;
+END $$;
+
+ALTER TABLE "public"."activities" VALIDATE CONSTRAINT "activities_ustadz_id_fkey";
+
+COMMIT;


### PR DESCRIPTION
The previous migration files failed to rename all `ustad_` to `ustadz_`.