### PR TITLE
fix(progressgrid): add weekends to progress grid

### DIFF
--- a/src/components/Progress/ProgressGrid.stories.tsx
+++ b/src/components/Progress/ProgressGrid.stories.tsx
@@ -4,8 +4,6 @@ import { ComponentProps, useState } from 'react'
 import dayjs from 'dayjs'
 
 export function ProgressGridStory() {
-  const [lajnahJuzMilestone, setlajnahJuzMilestone] = useState(5)
-
   const [date, setDate] = useState(new Date())
   const data: ComponentProps<typeof ProgressGrid>['activities'] = [
     ...generateData('Sabaq', date),
@@ -14,42 +12,18 @@ export function ProgressGridStory() {
   ]
 
   return (
-    <div className='flex flex-col gap-y-8'>
+    <div className='grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-8'>
       <div>
-        <label
-          htmlFor='lajnahJuzMilestone'
-          className='block text-sm/6 font-medium text-gray-900'
-        >
-          Milestone juz saat ini (isi -1 untuk tidak ada milestone)
-        </label>
-        <div className='mt-2'>
-          <input
-            id='lajnahJuzMilestone'
-            type='text'
-            className='block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm/6'
-            placeholder='Manzil juz milestone'
-            defaultValue={lajnahJuzMilestone}
-            onBlur={(e) => {
-              const value = e.currentTarget.value
-              if (isNaN(Number(value))) return
-
-              setlajnahJuzMilestone(Number(value))
-            }}
-          />
-        </div>
-      </div>
-
-      <hr />
-
-      <div className='grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-8'>
         <ProgressGrid
           activities={data}
           date={date}
           onChangeDate={setDate}
-          lajnahJuzMilestone={
-            lajnahJuzMilestone > -1 ? lajnahJuzMilestone : undefined
-          }
+          lajnahJuzMilestone={5}
         />
+      </div>
+
+      <div>
+        <ProgressGrid activities={data} date={date} onChangeDate={setDate} />
       </div>
     </div>
   )
@@ -59,10 +33,10 @@ function generateData(
   type: ActivityTypeKey,
   date: Date
 ): ComponentProps<typeof ProgressGrid>['activities'] {
-  const endDate = dayjs(date).day(5)
+  const endDate = dayjs(date).day(6)
   const pageAmount = endDate.date() % 6
 
-  return Array.from(new Array(5), (_, idx) => ({
+  return Array.from(new Array(7), (_, idx) => ({
     page_amount: idx === 0 ? null : pageAmount + idx,
     type,
     created_at: dayjs(endDate).add(-idx, 'day').toISOString()

--- a/src/components/Progress/ProgressGrid.tsx
+++ b/src/components/Progress/ProgressGrid.tsx
@@ -26,8 +26,8 @@ export function ProgressGrid({
   onChangeDate,
   lajnahJuzMilestone
 }: Props) {
-  const startDate = dayjs(date).day(1)
-  const endDate = dayjs(date).day(5)
+  const startDate = dayjs(date).day(0)
+  const endDate = dayjs(date).day(6)
 
   const { grid, headers } = getInitialVariables(startDate, endDate)
 


### PR DESCRIPTION
Due to the recent change here in the design, we need to also update the `<ProgressGrid>` component so it includes weekend as well. Also removes the unnecessary input in the story, I could've just used multiple `<ProgressGrid>` 🤦‍♂️ 

![Untitled-1](https://github.com/user-attachments/assets/ea931172-ee4d-4323-9ab8-1f141a452a97)

Video:

https://github.com/user-attachments/assets/39d5cb45-614a-4ae0-9e75-da2585e6ecbe

