### PR TITLE
feat: create checkpoint table

### DIFF
--- a/.snaplet/dataModel.json
+++ b/.snaplet/dataModel.json
@@ -422,6 +422,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": false
+        },
+        {
+          "name": "checkpoint",
+          "type": "checkpoint",
+          "isRequired": false,
+          "kind": "object",
+          "relationName": "checkpointToactivities",
+          "relationFromFields": [],
+          "relationToFields": [],
+          "isList": true,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
         }
       ],
       "uniqueConstraints": [
@@ -713,6 +727,164 @@
         {
           "name": "bname",
           "fields": ["name"],
+          "nullNotDistinct": false
+        }
+      ]
+    },
+    "checkpoint": {
+      "id": "public.checkpoint",
+      "schemaName": "public",
+      "tableName": "checkpoint",
+      "fields": [
+        {
+          "id": "public.checkpoint.id",
+          "name": "id",
+          "columnName": "id",
+          "type": "int8",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": true,
+          "sequence": {
+            "identifier": "\"public\".\"checkpoint_id_seq\"",
+            "increment": 1,
+            "start": 1
+          },
+          "hasDefaultValue": false,
+          "isId": true,
+          "maxLength": null
+        },
+        {
+          "id": "public.checkpoint.student_id",
+          "name": "student_id",
+          "columnName": "student_id",
+          "type": "int8",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.checkpoint.start_date",
+          "name": "start_date",
+          "columnName": "start_date",
+          "type": "timestamp",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.checkpoint.end_date",
+          "name": "end_date",
+          "columnName": "end_date",
+          "type": "timestamp",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.checkpoint.page_count_accumulation",
+          "name": "page_count_accumulation",
+          "columnName": "page_count_accumulation",
+          "type": "float4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.checkpoint.last_activity_id",
+          "name": "last_activity_id",
+          "columnName": "last_activity_id",
+          "type": "int8",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.checkpoint.part_count",
+          "name": "part_count",
+          "columnName": "part_count",
+          "type": "float4",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.checkpoint.status",
+          "name": "status",
+          "columnName": "status",
+          "type": "varchar",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "name": "activities",
+          "type": "activities",
+          "isRequired": true,
+          "kind": "object",
+          "relationName": "checkpointToactivities",
+          "relationFromFields": ["last_activity_id"],
+          "relationToFields": ["id"],
+          "isList": false,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        },
+        {
+          "name": "students",
+          "type": "students",
+          "isRequired": true,
+          "kind": "object",
+          "relationName": "checkpointTostudents",
+          "relationFromFields": ["student_id"],
+          "relationToFields": ["id"],
+          "isList": false,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": "checkpoint_pkey",
+          "fields": ["id"],
           "nullNotDistinct": false
         }
       ]
@@ -4750,6 +4922,20 @@
           "isRequired": false,
           "kind": "object",
           "relationName": "activitiesTostudents",
+          "relationFromFields": [],
+          "relationToFields": [],
+          "isList": true,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        },
+        {
+          "name": "checkpoint",
+          "type": "checkpoint",
+          "isRequired": false,
+          "kind": "object",
+          "relationName": "checkpointTostudents",
           "relationFromFields": [],
           "relationToFields": [],
           "isList": true,

--- a/src/models/database.types.ts
+++ b/src/models/database.types.ts
@@ -119,6 +119,54 @@ export type Database = {
           }
         ]
       }
+      checkpoint: {
+        Row: {
+          end_date: string | null
+          id: number
+          last_activity_id: number
+          page_count_accumulation: number
+          part_count: number | null
+          start_date: string
+          status: string
+          student_id: number
+        }
+        Insert: {
+          end_date?: string | null
+          id?: never
+          last_activity_id: number
+          page_count_accumulation: number
+          part_count?: number | null
+          start_date: string
+          status: string
+          student_id: number
+        }
+        Update: {
+          end_date?: string | null
+          id?: never
+          last_activity_id?: number
+          page_count_accumulation?: number
+          part_count?: number | null
+          start_date?: string
+          status?: string
+          student_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'checkpoint_last_activity_id_fkey'
+            columns: ['last_activity_id']
+            isOneToOne: false
+            referencedRelation: 'activities'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'checkpoint_student_id_fkey'
+            columns: ['student_id']
+            isOneToOne: false
+            referencedRelation: 'students'
+            referencedColumns: ['id']
+          }
+        ]
+      }
       halaqah: {
         Row: {
           academic_year: number | null

--- a/supabase/migrations/20241203111238_create_checkpoint_table.sql
+++ b/supabase/migrations/20241203111238_create_checkpoint_table.sql
@@ -1,0 +1,26 @@
+CREATE TABLE checkpoint (
+    id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    student_id BIGINT NOT NULL,
+    start_date TIMESTAMP NOT NULL,
+    end_date TIMESTAMP DEFAULT NULL,
+    page_count_accumulation FLOAT4 NOT NULL,
+    last_activity_id BIGINT NOT NULL,
+    part_count FLOAT4,
+    status VARCHAR NOT NULL,
+    FOREIGN KEY (student_id) REFERENCES students(id),
+    FOREIGN KEY (last_activity_id) REFERENCES activities(id)
+    );
+
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_checkpoint_updated_at
+BEFORE UPDATE ON checkpoint
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
Close #84 

Create checkpoint table to record student checkpoint for exam which accumulate activities.

Create `checkpoint` table to record student checkpoint for exam which accumulate activities.

columns:

1. student_id = number
2. start_date = date - default today
3. end_date = date - filled when user finish exam
4. page_count_accumulation = number
5. last_activity = id
6. part = jumlah juz accomplished, verbosity purpose (can be used for infographic in calendar as well)
7. status = approaching | ready | in_exam | completed (completed here for verbosity purpose, since we can identify from end_date as well)

Catatan:
1. start_date akan terisi otomatis saat ustad input data checkpoint
2. end_date akan terisi saat ustad update status checkpoint saat ujian telah selesai
3. page_count_accumulation akan di hitung dari = jumlah completed activity page_count setelah last_activity.
4. Ustad tidak dapat membuat checkpoint jika terdapat activity yang dalam keadaan draft
5. Data berikut di input dan di manage ustad, dengan entry point di halaman detail santri


Status explanation:

1. approaching = Sebentar lagi lajnah (pencapaian hafalan hampir sampai ke checkpoint lajnah)
2. ready = Siap lajnah (pencapaian hafalan TEPAT sampai di checkpoint lajnah)
3. in_exam = Sedang lajnah (pencapaian hafalan TEPAT sampai di checkpoint DAN sedang melakukan ujian)
4. completed = Ujian selesai