### PR TITLE
chore: Set output to standalone only when docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN npm ci
 FROM base AS builder
 ARG NEXT_PUBLIC_APP_VERSION
 ENV NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION
+ENV DOCKER_BUILD=true
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  output: 'standalone'
+  // https://nextjs.org/docs/advanced-features/output-file-tracing#automatically-copying-traced-files
+  output: process.env.DOCKER_BUILD === 'true' ? 'standalone' : undefined
 }
 
 export default nextConfig


### PR DESCRIPTION
Skip the following warning:

 ⚠ "next start" does not work with "output: standalone" configuration. Use "node .next/standalone/server.js" instead.