### PR TITLE
chore: Consistent surah name and casing

### DIFF
--- a/src/app/ustadz/santri/[slug]/activities/add/page.tsx
+++ b/src/app/ustadz/santri/[slug]/activities/add/page.tsx
@@ -81,7 +81,7 @@ export default async function AddActivity(props: AddActivityProps) {
         ustadName={halaqah?.data?.ustadz?.name ?? ''}
         lastSurah={
           lastActivity
-            ? `${lastActivity?.end_surah} : ${lastActivity?.end_verse}`
+            ? `${lastActivity?.end_surah}: ${lastActivity?.end_verse}`
             : ''
         }
       />

--- a/src/app/ustadz/santri/[slug]/activities/components/Halaqah/index.tsx
+++ b/src/app/ustadz/santri/[slug]/activities/components/Halaqah/index.tsx
@@ -51,7 +51,7 @@ function HalaqahCard(props: HalaqahCardProps) {
           </div>
 
           <div className='w-full text-ellipsis line-clamp-2'>
-            Q.s {lastSurah || '-'}
+            {lastSurah || '-'}
           </div>
         </div>
       </CardContent>

--- a/src/utils/supabase/models/activities.ts
+++ b/src/utils/supabase/models/activities.ts
@@ -114,7 +114,7 @@ export class Activities extends Base {
           start_surah: surah.find((s) => s.id === item.start_surah)
             ?.name_simple,
           start_surah_id: item.start_surah,
-          end_surah: surah.find((s) => s.id === item.end_surah)?.name_simple,
+          end_surah: surah.find((s) => s.id === item.end_surah)?.name,
           end_surah_id: item.end_surah,
           start_verse: item.start_verse,
           end_verse: item.end_verse,


### PR DESCRIPTION
This ensures the surah name uses "name" instead of "name_simple". Also, it sets title-case for "Catatan Lain".

<img width="491" alt="image" src="https://github.com/user-attachments/assets/cb805ae2-afd9-4784-81f4-ff7db2de0f7b">
