### PR TITLE
fix: Render alert when missingLocationPermissionMessage is truthy

### DIFF
--- a/src/app/ustadz/components/UstadzHomeHeader.tsx
+++ b/src/app/ustadz/components/UstadzHomeHeader.tsx
@@ -29,7 +29,7 @@ export function UstadzHomeHeader({ displayName }: Props) {
         name={displayName}
         salahPrayerTimes={alAdhanInfo?.timings}
       >
-        {!missingLocationPermissionMessage && (
+        {missingLocationPermissionMessage && (
           <div className='flex gap-x-2 text-mtmh-sm-regular text-mtmh-red-light'>
             <div className='flex flex-col justify-center'>
               <CircleAlert aria-hidden size={16} />


### PR DESCRIPTION
We should render the alert only when `missingLocationPermissionMessage` is truthy.