### PR TITLE
chore: Use mtmh-warning-70 for tamarind badge

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -9,7 +9,7 @@ interface BadgeProps {
 const COLOR_TO_CLASSNAME_RECORD: Record<BadgeProps['color'], string> = {
   blue: 'bg-mtmh-blue-base',
   green: 'bg-mtmh-green-base',
-  tamarind: 'bg-mtmh-tamarind-base',
+  tamarind: 'bg-mtmh-warning-70', // FIXME: We should have a color-naming pattern for this.
   mute: 'bg-mtmh-snow-base'
 }
 


### PR DESCRIPTION
Use `mtmh-warning-70` as tamarind badge color for now. Until we can resolve: https://github.com/khutwah/khutwah-web/issues/113.

![image](https://github.com/user-attachments/assets/8a00947d-f383-4ba8-951c-88ea901c2b45)
