### PR TITLE
chore: Tidy up santri's aktivitas page

### DIFF
--- a/src/app/santri/aktivitas/page.tsx
+++ b/src/app/santri/aktivitas/page.tsx
@@ -35,6 +35,7 @@ export default async function Aktivitas() {
             <ProgressGridWithState
               activities={activities.data}
               className='border-none rounded-none'
+              editable={false}
             />
           </CardContent>
         </Card>

--- a/src/components/Progress/ProgressGrid.stories.tsx
+++ b/src/components/Progress/ProgressGrid.stories.tsx
@@ -25,6 +25,17 @@ export function ProgressGridStory() {
       </div>
 
       <div>
+        <ProgressGrid
+          activities={data}
+          date={date}
+          onChangeDate={setDate}
+          status='lajnah-exam'
+          statusParameter='5'
+          editable={false}
+        />
+      </div>
+
+      <div>
         <ProgressGrid activities={data} date={date} onChangeDate={setDate} />
       </div>
     </div>
@@ -69,6 +80,7 @@ export function StatusStory() {
       <ProgressGridStatus status='lajnah-approaching' parameter='5' />
       <ProgressGridStatus status='lajnah-ready' parameter='5' />
       <ProgressGridStatus status='lajnah-exam' parameter='5' />
+      <ProgressGridStatus status='lajnah-exam' parameter='5' editable={false} />
     </div>
   )
 }

--- a/src/components/Progress/ProgressGrid.tsx
+++ b/src/components/Progress/ProgressGrid.tsx
@@ -17,6 +17,7 @@ interface Props {
   date: Date
   onChangeDate: Dispatch<SetStateAction<Date>>
   status?: ProgressGridStatusProps['status']
+  editable?: ProgressGridStatusProps['editable']
   statusParameter?: ProgressGridStatusProps['parameter']
   className?: string
 }
@@ -37,6 +38,7 @@ export function ProgressGrid({
   date,
   onChangeDate,
   status,
+  editable,
   statusParameter,
   className
 }: Props) {
@@ -147,7 +149,11 @@ export function ProgressGrid({
         </div>
       </div>
 
-      <ProgressGridStatus status={status} parameter={statusParameter} />
+      <ProgressGridStatus
+        status={status}
+        parameter={statusParameter}
+        editable={editable}
+      />
     </div>
   )
 }

--- a/src/components/Progress/ProgressGridStatus.tsx
+++ b/src/components/Progress/ProgressGridStatus.tsx
@@ -7,6 +7,7 @@ import StatusLajnahReady from './statuses/lajnah-ready.png'
 import StatusLajnahExam from './statuses/lajnah-exam.png'
 
 export interface ProgressGridStatusProps {
+  editable?: boolean
   status?:
     | 'default'
     | 'lajnah-approaching'
@@ -17,6 +18,7 @@ export interface ProgressGridStatusProps {
 }
 
 export function ProgressGridStatus({
+  editable = true,
   status,
   parameter
 }: ProgressGridStatusProps) {
@@ -45,7 +47,7 @@ export function ProgressGridStatus({
               {resolvedStatus.description}
             </div>
           </div>
-          <Pencil size={16} aria-hidden='true' />
+          {editable && <Pencil size={16} aria-hidden='true' />}
         </div>
       </div>
     </button>


### PR DESCRIPTION
This syncs santri/activitas with ustadz/detil-santri page.

<img width="393" alt="image" src="https://github.com/user-attachments/assets/31363a0c-784b-4930-813b-06f67a23cbf9">

Notice that in santri/activitas there is no edit icon.