### PR TITLE
fix: only show completed activities for progress grid

### DIFF
--- a/src/app/ustadz/santri/[slug]/page.tsx
+++ b/src/app/ustadz/santri/[slug]/page.tsx
@@ -37,6 +37,7 @@ export default async function DetailSantri({
       student_id: student.data.id,
       start_date: dayjs().startOf('week').toISOString(),
       end_date: dayjs().endOf('week').toISOString(),
+      status: ActivityStatus.completed,
       limit: 21
     })
 


### PR DESCRIPTION
Exclude draft activity from progress grid.

<img width="508" alt="Screenshot 2024-12-13 at 09 53 45" src="https://github.com/user-attachments/assets/6d63e7e6-9d7b-4ff5-97a9-98ff2144d046" />
