### PR TITLE
fix: first click unresponsive tags

### DIFF
--- a/src/app/ustadz/santri/[slug]/activities/hooks/useActivityControlledValue.ts
+++ b/src/app/ustadz/santri/[slug]/activities/hooks/useActivityControlledValue.ts
@@ -73,7 +73,7 @@ export function useActivityControlledValue({
     endSurah: endSurah,
     startVerse: startVerse,
     endVerse: endVerse,
-    tags: tags,
+    tags: tags ?? [],
     achieveTarget
   }
 }

--- a/src/app/ustadz/santri/[slug]/activities/utils/form.ts
+++ b/src/app/ustadz/santri/[slug]/activities/utils/form.ts
@@ -11,8 +11,9 @@ export function getVerseItems(surahValue: number): ComboboxProps['items'] {
   })
 }
 
-export function toggleTag(tags: string[] | undefined, tag: string) {
-  const index = tags?.indexOf(tag)
+export function toggleTag(tags: string[], tag: string) {
+  const index = tags.indexOf(tag)
+
   if (index === -1) {
     return [...(tags || []), tag]
   }


### PR DESCRIPTION
Close #199 

Fix unresponsive tag picker when first click, caused by initial `tags` being undefined.

https://github.com/user-attachments/assets/20482815-0681-461d-9ab6-b27f3c12733c

