### PR TITLE
fix: Use client's TZ to infer "current date"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@supabase/supabase-js": "^2.46.1",
         "class-variance-authority": "0.7.0",
         "clsx": "^2.1.1",
+        "cookies-next": "^5.0.2",
         "dayjs": "^1.11.13",
         "lucide-react": "0.456.0",
         "next": "15.1.0",
@@ -5770,6 +5771,27 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cookies-next": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-5.0.2.tgz",
+      "integrity": "sha512-Ft5yXMbN6wMfgLiL5TMyPnxsjkW6UEjZw0YMoDMiF3F6iYdFPjiJEMugx/sivUr8G+0xPG80lBYqI2b+VquSuw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1"
+      },
+      "peerDependencies": {
+        "next": ">=15.0.0"
+      }
+    },
+    "node_modules/cookies-next/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@supabase/supabase-js": "^2.46.1",
     "class-variance-authority": "0.7.0",
     "clsx": "^2.1.1",
+    "cookies-next": "^5.0.2",
     "dayjs": "^1.11.13",
     "lucide-react": "0.456.0",
     "next": "15.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { Toaster } from '@/components/Toast/Toaster'
+import { TimezoneSetter } from '@/components/Timezone/Setter'
 
 export const metadata: Metadata = {
   title: 'MTMH',
@@ -15,8 +16,8 @@ export default function RootLayout({
   return (
     <html lang='en'>
       <body>
+        <TimezoneSetter />
         {children}
-
         <Toaster />
       </body>
     </html>

--- a/src/app/santri/aktivitas/components/ActivityGridSection.tsx
+++ b/src/app/santri/aktivitas/components/ActivityGridSection.tsx
@@ -12,6 +12,7 @@ import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
 
 import { Activities } from '@/utils/supabase/models/activities'
 import { getUser } from '@/utils/supabase/get-user'
+import getTimezoneInfo from '@/utils/get-timezone-info'
 export async function ActivityGridSection() {
   return (
     <section className='flex flex-col gap-y-4'>
@@ -43,12 +44,15 @@ export async function ActivityGridSection() {
 
 async function ActivityGrid() {
   const user = await getUser()
+  // This gets the current day in the client's timezone.
+  const tz = await getTimezoneInfo()
+  const day = dayjs().tz(tz)
 
   const activitiesInstance = new Activities()
   const activities = await activitiesInstance.list({
     parent_id: user.data?.id,
-    start_date: dayjs().startOf('week').toISOString(),
-    end_date: dayjs().endOf('week').toISOString()
+    start_date: day.startOf('week').toISOString(),
+    end_date: day.endOf('week').toISOString()
   })
 
   return (

--- a/src/app/ustadz/halaqah/page.tsx
+++ b/src/app/ustadz/halaqah/page.tsx
@@ -8,8 +8,14 @@ import { YourHalaqahList } from './components/YourHalaqahList'
 import { AllHalaqahList } from './components/AllHalaqahList'
 import { ErrorBoundary } from '@/components/ErrorBoundary/ErrorBoundary'
 import { StateMessage } from '@/components/StateMessage/StateMessage'
+import { Alert, AlertDescription } from '@/components/Alert/Alert'
+import { CircleAlert } from 'lucide-react'
+import getTimezoneInfo from '@/utils/get-timezone-info'
+import dayjs from '@/utils/dayjs'
 
-export default function HalaqahListPage() {
+export default async function HalaqahListPage() {
+  const tz = await getTimezoneInfo()
+  const day = dayjs().tz(tz)
   return (
     <Layout>
       <SearchProvider>
@@ -33,6 +39,12 @@ export default function HalaqahListPage() {
           }
         >
           <div className='p-6 space-y-8'>
+            <Alert variant='warning'>
+              <CircleAlert aria-hidden size={16} />
+              <AlertDescription>
+                Menampilkan data untuk hari {day.format('dddd, D MMMM YYYY')}.
+              </AlertDescription>
+            </Alert>
             <section>
               <h2 className='mb-3 text-mtmh-m-semibold'>Halaqah Anda</h2>
               <Suspense fallback={<HalaqahListSkeleton />}>

--- a/src/app/ustadz/santri/[slug]/page.tsx
+++ b/src/app/ustadz/santri/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { ActivityStatus, ActivityTypeKey } from '@/models/activities'
 import { Checkpoint } from '@/utils/supabase/models/checkpoint'
 import { CheckpointStatus } from '@/models/checkpoint'
 import { parseParameter } from '@/utils/parse-parameter'
+import getTimezoneInfo from '@/utils/get-timezone-info'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const DEFAULT_EMPTY_ARRAY: any[] = []
@@ -38,6 +39,9 @@ export default async function DetailSantri({
   if (!student.data) {
     pageContent = <div>Unexpected error: {student.error?.message}</div>
   } else {
+    // This gets the current day in the client's timezone.
+    const tz = await getTimezoneInfo()
+    const day = dayjs().tz(tz)
     const activitiesInstance = new Activities()
     const [
       activitiesPromise,
@@ -48,8 +52,8 @@ export default async function DetailSantri({
     ] = await Promise.allSettled([
       activitiesInstance.list({
         student_id: student.data.id,
-        start_date: dayjs().startOf('week').toISOString(),
-        end_date: dayjs().endOf('week').toISOString(),
+        start_date: day.startOf('week').toISOString(),
+        end_date: day.endOf('week').toISOString(),
         limit: 21
       }),
       activitiesInstance.list({

--- a/src/app/ustadz/santri/page.tsx
+++ b/src/app/ustadz/santri/page.tsx
@@ -13,9 +13,14 @@ import { Activities } from '@/utils/supabase/models/activities'
 import { dayjs } from '@/utils/dayjs'
 import SearchProvider from '../components/Search/SearchProvider'
 import { StateMessage } from '@/components/StateMessage/StateMessage'
+import { Alert, AlertDescription } from '@/components/Alert/Alert'
+import { CircleAlert } from 'lucide-react'
+import getTimezoneInfo from '@/utils/get-timezone-info'
 
 export default async function Santri() {
   const user = await getUser()
+  const tz = await getTimezoneInfo()
+  const day = dayjs().tz(tz)
 
   const studentsInstance = new Students()
   const activitiesInstance = new Activities()
@@ -26,8 +31,8 @@ export default async function Santri() {
     }),
     activitiesInstance.list({
       ustadz_id: user.data?.id,
-      start_date: dayjs().startOf('day').toISOString(),
-      end_date: dayjs().endOf('day').toISOString()
+      start_date: day.startOf('day').toISOString(),
+      end_date: day.endOf('day').toISOString()
     })
   ])
 
@@ -54,6 +59,12 @@ export default async function Santri() {
           }
         >
           <div className='p-6 space-y-8'>
+            <Alert variant='warning'>
+              <CircleAlert aria-hidden size={16} />
+              <AlertDescription>
+                Menampilkan data untuk hari {day.format('dddd, D MMMM YYYY')}.
+              </AlertDescription>
+            </Alert>
             <Suspense fallback={<SantriListSkeleton />}>
               <SantriList
                 students={students.data}

--- a/src/components/ActivityCard/ActivityCard.tsx
+++ b/src/components/ActivityCard/ActivityCard.tsx
@@ -120,7 +120,7 @@ export function ActivityCard({
         {status === ActivityStatus.draft && (
           <CardFooter>
             <Alert variant='warning'>
-              <CircleAlert size={16} />
+              <CircleAlert aria-hidden size={16} />
               <AlertDescription>
                 Aktivitas {type} ini perlu dilengkapi.
               </AlertDescription>

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -12,7 +12,7 @@ export function BottomNavbarStory() {
       </Alert>
 
       <Alert variant='warning'>
-        <CircleAlert size={16} />
+        <CircleAlert aria-hidden size={16} />
         <AlertDescription>Mohon data dilengkapi.</AlertDescription>
       </Alert>
 

--- a/src/components/Timezone/Setter.tsx
+++ b/src/components/Timezone/Setter.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useEffect } from 'react'
+import { setCookie } from 'cookies-next'
+
+export function TimezoneSetter() {
+  useEffect(() => {
+    // This feature is wildly available: https://caniuse.com/?search=datetimeformat.
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    setCookie('timezone', timezone, { maxAge: 30 * 24 * 60 * 60 }) // 30 days.
+  }, [])
+
+  return null
+}

--- a/src/utils/dayjs.ts
+++ b/src/utils/dayjs.ts
@@ -1,10 +1,12 @@
 import { default as _dayjs } from 'dayjs'
 import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 
 import 'dayjs/locale/id'
 
 _dayjs.extend(utc)
+_dayjs.extend(timezone)
 _dayjs.extend(isSameOrAfter)
 
 _dayjs.locale('id')

--- a/src/utils/get-timezone-info/index.ts
+++ b/src/utils/get-timezone-info/index.ts
@@ -1,0 +1,6 @@
+import { cookies } from 'next/headers'
+
+export default async function getTimezoneInfo() {
+  const cookieStore = await cookies()
+  return cookieStore.get('timezone')?.value || 'UTC'
+}

--- a/src/utils/supabase/models/halaqah.ts
+++ b/src/utils/supabase/models/halaqah.ts
@@ -2,6 +2,7 @@ import { Base } from './base'
 import { RoleFilter } from '@/models/supabase/models/filter'
 import { ApiError } from '@/utils/api-error'
 import dayjs from '@/utils/dayjs'
+import getTimezoneInfo from '@/utils/get-timezone-info'
 interface GetFilter extends RoleFilter {
   start_date?: string
   end_date?: string
@@ -9,9 +10,11 @@ interface GetFilter extends RoleFilter {
 
 export class Halaqah extends Base {
   async list(filter: GetFilter = {}) {
+    const tz = await getTimezoneInfo()
+    const day = dayjs().tz(tz)
     const {
-      start_date = dayjs().utc().startOf('day').toISOString(),
-      end_date = dayjs().utc().endOf('day').toISOString(),
+      start_date = day.startOf('day').utc().toISOString(),
+      end_date = day.endOf('day').utc().toISOString(),
       student_id,
       ustadz_id
     } = filter ?? {}
@@ -142,9 +145,12 @@ export class Halaqah extends Base {
   }
 
   async get(id: number, filter?: GetFilter) {
+    const tz = await getTimezoneInfo()
+    const day = dayjs().tz(tz)
+
     const {
-      start_date = dayjs().utc().startOf('day').toISOString(),
-      end_date = dayjs().utc().endOf('day').toISOString()
+      start_date = day.startOf('day').utc().toISOString(),
+      end_date = day.endOf('day').utc().toISOString()
     } = filter ?? {}
 
     let query = (await this.supabase)


### PR DESCRIPTION
This PR uses the browser's [`Intl.DateTimeFormat().resolvedOptions().timeZone`](https://caniuse.com/mdn-javascript_builtins_intl_datetimeformat_resolvedoptions_computed_timezone) to infer the client's TZ. This information is then sent to the server via a client cookie.

From the caller site, one needs to get the TZ and then set it to the local `dayjs` instance: `dayjs().tz(<INFERRED_TZ>)`.