### PR TITLE
chore: Run generateBuildId to uniquely define a deployment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   // https://nextjs.org/docs/advanced-features/output-file-tracing#automatically-copying-traced-files.
   output: process.env.DOCKER_BUILD === 'true' ? 'standalone' : undefined,
+  generateBuildId() {
+    return process.env.NEXT_PUBLIC_APP_VERSION || 'development'
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
Ref: https://nextjs.org/docs/app/api-reference/config/next-config-js/generateBuildId