### PR TITLE
fix: load more appearance

### DIFF
--- a/src/app/ustadz/aktivitas/components/ActivityList/Client.tsx
+++ b/src/app/ustadz/aktivitas/components/ActivityList/Client.tsx
@@ -33,6 +33,13 @@ export function ActivityListClient({
           setFinish(true)
           return
         }
+
+        const data = response.data!
+        const length = data.length
+
+        if (length < LIMIT) {
+          setFinish(true)
+        }
         setActivities((p) => [...p, ...response.data!])
         setOffset((_offset) => _offset + LIMIT)
       }


### PR DESCRIPTION
## Description
1. Prevent load more button from appearing when initial activities length is less than the limit (10)
2. Prevent load more button from appearing when activities length after pagination is less than the limit (10)


## Remark

### Before
<img width="551" alt="Screenshot 2024-12-20 at 14 05 00" src="https://github.com/user-attachments/assets/2e8a9987-27e3-49c8-af1c-566f64648b12" />

### After
<img width="518" alt="Screenshot 2024-12-20 at 14 06 46" src="https://github.com/user-attachments/assets/c028bd75-167f-4f87-a126-b9c3aa1da3dc" />
