### PR TITLE
fix(santri/aktivitas): Load ProgressGridStatus data

### DIFF
--- a/src/app/ustadz/santri/[slug]/page.tsx
+++ b/src/app/ustadz/santri/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { Activities } from '@/utils/supabase/models/activities'
 import dayjs from '@/utils/dayjs'
 import Image from 'next/image'
 import SampleSantriAvatar from '@/assets/sample-santri-photo.png'
-import { ProgressGridWithNav } from '@/components/Progress/ProgressGrid'
+import { ProgressGridWithNavigation } from '@/components/Progress/ProgressGrid'
 import { SantriActivityHeader } from '@/components/SantriActivity/Header'
 import { ActivityPopup } from '@/components/ActivityPopup'
 import { ActivityCard } from '@/components/ActivityCard/ActivityCard'
@@ -215,7 +215,7 @@ export default async function DetailSantri({
                   }
                 />
               ) : (
-                <ProgressGridWithNav
+                <ProgressGridWithNavigation
                   activities={activities?.data ?? DEFAULT_EMPTY_ARRAY}
                   date={day.toDate()}
                   className='border-none rounded-none'

--- a/src/components/Progress/ProgressGrid.tsx
+++ b/src/components/Progress/ProgressGrid.tsx
@@ -206,7 +206,7 @@ export function ProgressGrid({
 /**
  * `<ProgressGrid>` component wrapped with event handlers to update the query parameters whenever the date changes.
  */
-export function ProgressGridWithNav(props: Omit<Props, 'onChangeDate'>) {
+export function ProgressGridWithNavigation(props: Omit<Props, 'onChangeDate'>) {
   const router = useRouter()
 
   return (


### PR DESCRIPTION
This ensures we load all required data to show ProgressGridStatus on the `santri/aktivitas` page.